### PR TITLE
Replace the BrowserModule import with CommonModule.

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs';
 import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { CommonModule } from '@angular/platform-browser';
+import { CommonModule } from '@angular/common';
 
 import { BrMaskerIonic3 } from './directives/brmasker-ionic-3';
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs';
 import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
+import { CommonModule } from '@angular/platform-browser';
 
 import { BrMaskerIonic3 } from './directives/brmasker-ionic-3';
 
@@ -13,7 +13,7 @@ import { BrMaskerIonic3 } from './directives/brmasker-ionic-3';
     BrMaskerIonic3
   ],
   imports: [
-    BrowserModule
+    CommonModule
   ],
   schemas: [
     CUSTOM_ELEMENTS_SCHEMA


### PR DESCRIPTION
Replace the BrowserModule import with CommonModule. Correction for the bug in lazy load "BrowserModule has already been loaded. If you need access to common directives such as NgIf and NgFor a lazy loaded module, import CommonModule instead.".