### PR TITLE
Removed Observable import - import not used

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,5 @@
-import { Observable } from 'rxjs';
+import { CommonModule } from '@angular/common';
 import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
 
 import { BrMaskerIonic3 } from './directives/brmasker-ionic-3';
 
@@ -13,7 +12,7 @@ import { BrMaskerIonic3 } from './directives/brmasker-ionic-3';
     BrMaskerIonic3
   ],
   imports: [
-    BrowserModule
+    CommonModule
   ],
   schemas: [
     CUSTOM_ELEMENTS_SCHEMA


### PR DESCRIPTION
1 - import do Observable removido. O import `import { Observable } from 'rxjs';` custa 199.1Kb ao projeto e não está sendo usado. Esse import importa praticamente o rxjs inteiro. Caso realmente precise desse import, dê preferência para usar `import { Observable } from 'rxjs/Observable';` que tem custo de apenas 9kb ao projeto.

2 - O BrowserModule deve somente ser referenciado pelo `app.module.ts` da aplicação que irá usar o plugin. O correto é importar o `import { CommonModule } from '@angular/common';` caso realmente precise de alguma coisa desse módulo.  Esse fix está no PR #4.