### PR TITLE
Quick fix for when no digits are included in the input

### DIFF
--- a/src/directives/brmasker-ionic-3.ts
+++ b/src/directives/brmasker-ionic-3.ts
@@ -253,7 +253,9 @@ export class BrMaskerIonic3 implements OnInit, ControlValueAccessor {
     let val = value.replace(/\D/gi, '');
     const reverse = val.toString().split('').reverse().join('');
     const thousands = reverse.match(/\d{1,3}/g);
-    val = thousands.join(`${this.brmasker.thousand || '.'}`).split('').reverse().join('');
+    if (thousands) {
+        return thousands.join(`${this.brmasker.thousand || '.'}`).split('').reverse().join('');
+    }
     return val;
   }
 


### PR DESCRIPTION
The user guide [example for thousands](https://github.com/amarkes/br-masker-ionic-3#example-for-thousand-number) throws an error if you enter a character, see gif

![brmasker](https://user-images.githubusercontent.com/4732694/46315545-073a5b80-c5ce-11e8-9387-0a485656d2b4.gif)

Solves Issue #64 